### PR TITLE
Bug: Fixing CI Deploy error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "CI= react-scripts build",
     "test": "react-scripts jest",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Bug: Changed Build script from 
"react-scripts build"
to
"CI= react-scripts build"

to by pass CI Error - Warnings are treated as errors and build will fail